### PR TITLE
Expose METIS contiguous partition flag through wrapper

### DIFF
--- a/pymetis/__init__.py
+++ b/pymetis/__init__.py
@@ -119,4 +119,5 @@ def part_graph(nparts, adjacency=None, xadj=None, adjncy=None,
         # metis has a bug in this case--it disregards the index base
         return 0, [0] * (len(xadj)-1)
 
-    return part_graph(nparts, xadj, adjncy, vweights, eweights, recursive, contiguous)
+    return part_graph(nparts, xadj, adjncy, vweights,
+                      eweights, recursive, contiguous)

--- a/pymetis/__init__.py
+++ b/pymetis/__init__.py
@@ -68,7 +68,7 @@ def nested_dissection(adjacency=None, xadj=None, adjncy=None):
 
 
 def part_graph(nparts, adjacency=None, xadj=None, adjncy=None,
-        vweights=None, eweights=None, recursive=None):
+        vweights=None, eweights=None, recursive=None, contiguous=None):
     """Return a partition (cutcount, part_vert) into nparts for an input graph.
 
     The input graph is given in either a Pythonic way as the `adjacency' parameter
@@ -110,10 +110,13 @@ def part_graph(nparts, adjacency=None, xadj=None, adjncy=None,
         else:
             recursive = True
 
+    if contiguous is None:
+        contiguous = False
+
     from pymetis._internal import part_graph
 
     if nparts == 1:
         # metis has a bug in this case--it disregards the index base
         return 0, [0] * (len(xadj)-1)
 
-    return part_graph(nparts, xadj, adjncy, vweights, eweights, recursive)
+    return part_graph(nparts, xadj, adjncy, vweights, eweights, recursive, contiguous)

--- a/src/wrapper/wrapper.cpp
+++ b/src/wrapper/wrapper.cpp
@@ -123,7 +123,8 @@ namespace
       const py::object &adjncy_py,
       const py::object &vwgt_py,
       const py::object &adjwgt_py,
-      bool recursive)
+      bool recursive,
+      bool contiguous)
   {
     idx_t nvtxs = py::len(xadj_py) - 1;
     vector<idx_t> xadj, adjncy, vwgt, adjwgt;
@@ -150,6 +151,9 @@ namespace
     idx_t options[METIS_NOPTIONS];
     METIS_SetDefaultOptions(options);
     options[METIS_OPTION_NUMBERING] = 0;  // C-style numbering
+
+    if (contiguous)
+        options[METIS_OPTION_CONTIG] = 1;
 
     idx_t edgecut;
     std::unique_ptr<idx_t []> part(new idx_t[nvtxs]);


### PR DESCRIPTION
Hi there,

First of all, many thanks for maintaining this repo!

I've come across an application with rather large graphs where I needed to set the METIS_OPTION_CONTIG flag
that forces contiguous partitions. In this PR I've exposed the flag through an additional argument to `pymetis.part_graph`.