### PR TITLE
Including ufactor and seed options

### DIFF
--- a/pymetis/__init__.py
+++ b/pymetis/__init__.py
@@ -112,8 +112,8 @@ def part_graph(nparts, adjacency=None, xadj=None, adjncy=None,
 
     recursive = kwargs.get('recursive', nparts <= 8)
     contiguous = kwargs.get('contiguous', False)
-    ufactor    = kwargs.get('ufactor', -1) # -1 reverts to METIS default
-    seed       = kwargs.get('seed', -1)    # -1 reverts to METIS default
+    ufactor = kwargs.get('ufactor', -1)  # -1 reverts to METIS default
+    seed = kwargs.get('seed', -1)        # -1 reverts to METIS default
 
     from pymetis._internal import part_graph
 

--- a/pymetis/__init__.py
+++ b/pymetis/__init__.py
@@ -68,7 +68,7 @@ def nested_dissection(adjacency=None, xadj=None, adjncy=None):
 
 
 def part_graph(nparts, adjacency=None, xadj=None, adjncy=None,
-        vweights=None, eweights=None, recursive=None, contiguous=None):
+        vweights=None, eweights=None, **kwargs):
     """Return a partition (cutcount, part_vert) into nparts for an input graph.
 
     The input graph is given in either a Pythonic way as the `adjacency' parameter
@@ -101,17 +101,19 @@ def part_graph(nparts, adjacency=None, xadj=None, adjncy=None,
         unweighted), then the adjwgt can be set to ``None``.
 
     (quoted with slight adaptations from the Metis docs)
+
+    kwargs:
+        *recursive  (bool): Use recursive mode
+        *contiguous (bool): Generate contiguous partitions
+        *ufactor    (int): Specify METIS ufactor
+        *seed       (int): Specify METIS seed
     """
     xadj, adjncy = _prepare_graph(adjacency, xadj, adjncy)
 
-    if recursive is None:
-        if nparts > 8:
-            recursive = False
-        else:
-            recursive = True
-
-    if contiguous is None:
-        contiguous = False
+    recursive = kwargs.get('recursive', nparts <= 8)
+    contiguous = kwargs.get('contiguous', False)
+    ufactor    = kwargs.get('ufactor', -1) # -1 reverts to METIS default
+    seed       = kwargs.get('seed', -1)    # -1 reverts to METIS default
 
     from pymetis._internal import part_graph
 
@@ -120,4 +122,4 @@ def part_graph(nparts, adjacency=None, xadj=None, adjncy=None,
         return 0, [0] * (len(xadj)-1)
 
     return part_graph(nparts, xadj, adjncy, vweights,
-                      eweights, recursive, contiguous)
+                      eweights, recursive, contiguous, seed, ufactor)

--- a/src/wrapper/wrapper.cpp
+++ b/src/wrapper/wrapper.cpp
@@ -124,7 +124,10 @@ namespace
       const py::object &vwgt_py,
       const py::object &adjwgt_py,
       bool recursive,
-      bool contiguous)
+      bool contiguous,
+      int  seed,
+      int  ufactor
+      )
   {
     idx_t nvtxs = py::len(xadj_py) - 1;
     vector<idx_t> xadj, adjncy, vwgt, adjwgt;
@@ -153,7 +156,11 @@ namespace
     options[METIS_OPTION_NUMBERING] = 0;  // C-style numbering
 
     if (contiguous)
-        options[METIS_OPTION_CONTIG] = 1;
+        options[METIS_OPTION_CONTIG] = contiguous;
+    if (ufactor > 0)
+        options[METIS_OPTION_UFACTOR] = ufactor;
+    if (seed > 0)
+        options[METIS_OPTION_SEED] = seed;
 
     idx_t edgecut;
     std::unique_ptr<idx_t []> part(new idx_t[nvtxs]);


### PR DESCRIPTION
In a recent application I needed control over the `seed` and `ufactor` parameters of METIS.
I've added them as configuration options and changed the signature of `part_graph` to use `**kwargs` for the optional flags as the list was starting to become pretty long.