### PR TITLE
Wrapper for METIS_PartMeshNodal as part_mesh

### DIFF
--- a/pymetis/__init__.py
+++ b/pymetis/__init__.py
@@ -239,7 +239,7 @@ def part_mesh(nparts, elements=None, eptr=None, eind=None, options=None):
     properties:
 
     - len(elements) needs to return the number of elements in the mesh
-    - ``elements[i]`` needs to be an iterable of vertex ids defining 
+    - ``elements[i]`` needs to be an iterable of vertex ids defining
       the ith element.
 
     Check the METIS manual for appropriate options.

--- a/pymetis/__init__.py
+++ b/pymetis/__init__.py
@@ -104,18 +104,19 @@ def _prepare_graph(adjacency, xadj, adjncy):
 
     return xadj, adjncy
 
-def _prepare_mesh(tri, eptr, eind):
-    if tri is not None:
+
+def _prepare_mesh(elements, eptr, eind):
+    if elements is not None:
         assert eptr is None
         assert eind is None
 
         eptr = [0]
         eind = []
 
-        for i in range(len(tri)):
-            adj = tri[i]
+        for i in range(len(elements)):
+            adj = elements[i]
             if adj is not None and len(adj):
-                assert max(adj) < len(tri)
+                assert max(adj) < len(elements)
             eind += list(map(int, adj))
             eptr.append(len(eind))
     else:
@@ -226,6 +227,7 @@ def part_graph(nparts, adjacency=None, xadj=None, adjncy=None,
     return part_graph(nparts, xadj, adjncy, vweights,
                       eweights, options, recursive)
 
+
 def part_mesh(nparts, elements=None, eptr=None, eind=None, options=None):
     """Return a partition (objval, epart, npart) into nparts for an input mesh.
 
@@ -237,12 +239,16 @@ def part_mesh(nparts, elements=None, eptr=None, eind=None, options=None):
     properties:
 
     - len(elements) needs to return the number of elements in the mesh
-    - ``elements[i]`` needs to be an iterable of vertice ids defining the ith element.
+    - ``elements[i]`` needs to be an iterable of vertex ids defining 
+      the ith element.
 
-    Check the METIS manual for appropriate options.  Otherwise standard defaults are used. 
+    Check the METIS manual for appropriate options.
+    Otherwise standard defaults are used.
     """
 
     eptr, eind, nn = _prepare_mesh(elements, eptr, eind)
+
+    ne = len(eptr)-1
 
     if options is None:
         options = Options()
@@ -251,10 +257,8 @@ def part_mesh(nparts, elements=None, eptr=None, eind=None, options=None):
         # metis has a bug in this case--it disregards the index base
         return 0, [0] * (ne-1), [0] * (nn-1)
 
-    ne = len(eptr)-1
-
     from pymetis._internal import part_mesh
     return part_mesh(ne, nn, eptr, eind, nparts, options)
-    
-    
+
+
 # vim: foldmethod=marker

--- a/pymetis/__init__.py
+++ b/pymetis/__init__.py
@@ -226,9 +226,23 @@ def part_graph(nparts, adjacency=None, xadj=None, adjncy=None,
     return part_graph(nparts, xadj, adjncy, vweights,
                       eweights, options, recursive)
 
-def part_mesh(nparts, tri=None, eptr=None, eind=None, options=None):
+def part_mesh(nparts, elements=None, eptr=None, eind=None, options=None):
+    """Return a partition (objval, epart, npart) into nparts for an input mesh.
 
-    eptr, eind, nn = _prepare_mesh(tri, eptr, eind)
+    The input mesh is given in either a Pythonic way as the *elements* parameter
+    or in the direct C-like way that Metis likes as *eptr* and *eind*. It
+    is an error to specify both graph inputs.
+
+    The Pythonic mesh specifier *elements* is required to have the following
+    properties:
+
+    - len(elements) needs to return the number of elements in the mesh
+    - ``elements[i]`` needs to be an iterable of vertice ids defining the ith element.
+
+    Check the METIS manual for appropriate options.  Otherwise standard defaults are used. 
+    """
+
+    eptr, eind, nn = _prepare_mesh(elements, eptr, eind)
 
     if options is None:
         options = Options()

--- a/test/test_metis.py
+++ b/test/test_metis.py
@@ -129,6 +129,7 @@ def test_tet_mesh(visualize=False):
             pyvtk.CellData(pyvtk.Scalars(epart, name="partition")))
         vtkelements.tofile("split_mesh.vtk")
 
+
 def test_cliques():
     adjacency_list = [
         np.array([1, 2]),


### PR DESCRIPTION
I have added a wrapper for METIS_PartMeshNodal as part_mesh. 

Added in a unit test which is similar to test_tet_mesh, which tests part_graph. Indeed I changed the name of that test to test_tet_graph and added test_tet_mesh to test part_mesh.