### PR TITLE
ci: add dependabot updates for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+    # Set update schedule for GitHub Actions
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+
+# vim: sw=4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,17 +21,10 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.12.1
-        # (here: set these in pyproject.toml to the extent possible)
-        # env:
-        #   CIBW_SOME_OPTION: value
-        #    ...
-        # with:
-        #   package-dir: .
-        #   output-dir: wheelhouse
-        #   config-file: "{package}/pyproject.toml"
 
       - uses: actions/upload-artifact@v3
         with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -45,6 +38,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
+          name: cibw-sdist
           path: dist/*.tar.gz
 
   upload_pypi:
@@ -57,10 +51,10 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
         with:
-          # unpacks default artifact into dist/
-          # if `name: artifact` is omitted, the action will create extra parent dir
-          name: artifact
+          # unpacks all CIBW artifacts into dist/
+          pattern: cibw-*
           path: dist
+          merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@v1.5.0
         with:


### PR DESCRIPTION
This also updates the artifact names so that moving to `upload-artifact@v4` actually works :crossed_fingers: 